### PR TITLE
[app] Fix PETLP text in light mode

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -42,7 +42,9 @@ function AppHeader() {
           <Typography variant="h6" component="div">
             RedditHarbor
           </Typography>
-          <Typography color="textSecondary">PETLP framework</Typography>
+          <Typography color="inherit" sx={{ opacity: 0.7 }}>
+            PETLP framework
+          </Typography>
         </Stack>
         <SignOutButton />
       </Toolbar>


### PR DESCRIPTION
### Before

<img width="294" height="45" alt="image" src="https://github.com/user-attachments/assets/63b893f5-b083-4d46-a33b-80db6efb9d03" />

### After

<img width="293" height="39" alt="image" src="https://github.com/user-attachments/assets/e9df57b7-61b9-45f7-a32d-41fb86211ec5" />

