### PR TITLE
[app] Redirect from `/` to `/dashboard`

### DIFF
--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -1,0 +1,9 @@
+import Container from '@mui/material/Container';
+
+export default function Dashboard() {
+  return (
+    <Container maxWidth="lg" sx={{ py: 3 }}>
+      TODO
+    </Container>
+  );
+}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,9 +1,14 @@
-import Container from '@mui/material/Container';
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 export default function Home() {
-  return (
-    <Container maxWidth="lg" sx={{ paddingY: 3 }}>
-      TODO
-    </Container>
-  );
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/dashboard');
+  }, [router]);
+
+  return null;
 }


### PR DESCRIPTION
Creating a dedicated `/dashboard` route makes it easier to introduce a home page in the future. For now, we'll just automatically redirect from `/` to `/dashboard` though.