### PR TITLE
[app] Remove default MUI button capitalisation

### DIFF
--- a/app/src/app/theme.ts
+++ b/app/src/app/theme.ts
@@ -6,5 +6,8 @@ export const theme = createTheme({
   cssVariables: true,
   typography: {
     fontFamily: 'var(--font-roboto)',
+    button: {
+      textTransform: 'initial',
+    },
   },
 });


### PR DESCRIPTION
### Before

<img width="188" height="40" alt="image" src="https://github.com/user-attachments/assets/5e263339-1eb3-4ef2-b091-2b672f229e50" />

### After

<img width="183" height="42" alt="image" src="https://github.com/user-attachments/assets/33e31b58-f076-422e-b271-c447d6f9028a" />
