### PR TITLE
[app] Remove redundant `handleClose` wrapper function

### DIFF
--- a/app/src/app/ApiKeysButton.tsx
+++ b/app/src/app/ApiKeysButton.tsx
@@ -228,13 +228,6 @@ function ApiKeysDialogContent({
   const formId = useId();
   const formRef = useRef<HTMLFormElement>(null);
 
-  function handleClose() {
-    if (isPending) {
-      return;
-    }
-    onClose();
-  }
-
   async function submitAction(
     _prevState: SaveApiKeysState | undefined,
     formData: FormData,
@@ -246,7 +239,7 @@ function ApiKeysDialogContent({
       startTransition(() => {
         onInvalidateApiKeys(encryptionKey);
       });
-      handleClose();
+      onClose();
     }
     return result;
   }


### PR DESCRIPTION
It was only getting called inside an action, but the action would close over `isPending=false`. In other words, as far as the action was concerned, `isPending` never became `true` so this check was pointless.