### PR TITLE
[app] Use `useLocalStorageState` hook for API keys too

### DIFF
--- a/app/src/app/actions/saveApiKeys.ts
+++ b/app/src/app/actions/saveApiKeys.ts
@@ -1,6 +1,5 @@
 import * as z from 'zod';
-import { encryptText } from '#app/utils/encryption.ts';
-import { setLocalStorageItem } from '#app/utils/useLocalStorageState.ts';
+import { encryptText, type EncryptedData } from '#app/utils/encryption.ts';
 
 export const apiKeysSchema = z
   .object({
@@ -25,6 +24,8 @@ export type SaveApiKeysState = {
 
 export async function saveApiKeys(
   encryptionKey: CryptoKey,
+  setApiKeys: (value: EncryptedData) => void,
+  invalidateApiKeys: (newApiKeys: ApiKeys) => void,
   formData: FormData,
 ): Promise<SaveApiKeysState | undefined> {
   const rawFormData = Object.fromEntries(formData);
@@ -42,7 +43,7 @@ export async function saveApiKeys(
       encryptionKey,
     );
 
-    setLocalStorageItem('apiKeys', JSON.stringify(encrypted));
+    setApiKeys(encrypted);
   } catch (error) {
     return {
       errors: {
@@ -56,4 +57,5 @@ export async function saveApiKeys(
       formData,
     };
   }
+  invalidateApiKeys(parsedResult.data);
 }

--- a/app/src/app/utils/useLocalStorageState.ts
+++ b/app/src/app/utils/useLocalStorageState.ts
@@ -139,11 +139,3 @@ export const useLocalStorageState =
   typeof window === 'undefined'
     ? useLocalStorageStateServer
     : useLocalStorageStateBrowser;
-
-/**
- * Set a localStorage item and emit a change event so that any
- * `useLocalStorageState` hooks listening to this key will update.
- */
-export function setLocalStorageItem(key: string, value: string | null) {
-  setValue(window.localStorage, key, value);
-}


### PR DESCRIPTION
This is a follow-up to #72. This refactor allows us to more easily handle cases where there are multiple browser tabs open.