### PR TITLE
[app] Replace useContext with use hook in ApiKeysDialogContext

### DIFF
--- a/app/src/app/ApiKeysDialogContext.tsx
+++ b/app/src/app/ApiKeysDialogContext.tsx
@@ -2,7 +2,7 @@
 
 import {
   createContext,
-  useContext,
+  use,
   useEffect,
   useEffectEvent,
   useRef,
@@ -158,7 +158,7 @@ export function ApiKeysDialogProvider({ children }: { children: ReactNode }) {
 }
 
 export function useApiKeysDialog() {
-  const context = useContext(ApiKeysDialogContext);
+  const context = use(ApiKeysDialogContext);
   if (!context) {
     throw new Error('Forgot to wrap in `ApiKeysDialogProvider`');
   }


### PR DESCRIPTION
Update to React 19's use() hook for reading context values instead
of the older useContext() pattern.