### PR TITLE
Add SessionStart hook for GH CLI installation on Claude Code web

### DIFF
--- a/.claude/scripts/installPackages.sh
+++ b/.claude/scripts/installPackages.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# https://docs.anthropic.com/en/docs/claude-code/claude-code-on-the-web#dependency-management
+
+# Only run in remote environments
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+  exit 0
+fi
+
+apt update && apt install gh -y
+cd "$CLAUDE_PROJECT_DIR/app" && pnpm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/installPackages.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- Add `.claude/settings.json` with `SessionStart` hook configuration
- Add `.claude/scripts/installPackages.sh` to install GitHub CLI and run `pnpm install`
- Script only runs in remote environments