### PR TITLE
Optimize SessionStart hook: use direct gh CLI download

### DIFF
--- a/.claude/scripts/installPackages.sh
+++ b/.claude/scripts/installPackages.sh
@@ -6,4 +6,8 @@ if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
   exit 0
 fi
 
-apt update && apt install gh -y
+# Install gh CLI via direct download (faster than apt update)
+GH_VERSION="2.45.0"
+curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" | tar -xz
+mv "gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/
+rm -rf "gh_${GH_VERSION}_linux_amd64"


### PR DESCRIPTION
Use direct binary download instead of apt (faster startup)