### PR TITLE
[app] Add `loading` prop to `Button` component

### DIFF
--- a/app/src/app/components/ui/button.tsx
+++ b/app/src/app/components/ui/button.tsx
@@ -2,9 +2,10 @@ import { Button as ButtonPrimitive } from '@base-ui/react/button';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '#app/utils/cn.ts';
+import { Spinner } from './spinner';
 
 const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-xs/relaxed font-medium focus-visible:ring-[2px] aria-invalid:ring-[2px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-xs/relaxed font-medium focus-visible:ring-[2px] aria-invalid:ring-[2px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none relative",
   {
     variants: {
       variant: {
@@ -38,18 +39,30 @@ const buttonVariants = cva(
   },
 );
 
+type ButtonProps = ButtonPrimitive.Props &
+  VariantProps<typeof buttonVariants> & {
+    loading?: boolean;
+  };
+
 function Button({
+  children,
   className,
+  loading,
+  disabled,
   variant = 'default',
   size = 'default',
   ...props
-}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+}: ButtonProps) {
   return (
     <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      disabled={disabled === true || loading}
       {...props}
-    />
+    >
+      {loading && <Spinner className="absolute" />}
+      <span className={cn('contents', loading && 'text-transparent')}>{children}</span>
+    </ButtonPrimitive>
   );
 }
 


### PR DESCRIPTION
Supports #177

## Summary
- Add `loading` boolean prop that shows a centered spinner
- Wrap children in span with `display: contents` to preserve layout
- Make text transparent when loading (preserves button width)
- Disable button interaction during loading state

🤖 Generated with [Claude Code](https://claude.com/claude-code)