### PR TITLE
[app] Migrate `Alert` component to shadcn

### DIFF
--- a/app/src/app/ApiKeysButton.tsx
+++ b/app/src/app/ApiKeysButton.tsx
@@ -14,7 +14,8 @@ import {
 } from 'react';
 import { ErrorBoundary, type FallbackProps } from 'react-error-boundary';
 import { useUser } from '@clerk/clerk-react';
-import Alert from '@mui/material/Alert';
+import { CircleAlert, CircleCheck } from 'lucide-react';
+import { Alert, AlertTitle } from '#app/components/ui/alert.tsx';
 import MuiButton from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
@@ -102,8 +103,9 @@ function ConnectionTestSection({ formRef }: ConnectionTestSectionProps) {
         ))}
       </Stack>
       {connectionTestState && (
-        <Alert severity={connectionTestState.success ? 'success' : 'error'}>
-          {connectionTestState.message}
+        <Alert variant={connectionTestState.success ? 'success' : 'destructive'}>
+          {connectionTestState.success ? <CircleCheck /> : <CircleAlert />}
+          <AlertTitle>{connectionTestState.message}</AlertTitle>
         </Alert>
       )}
     </>
@@ -214,8 +216,9 @@ function ApiKeysDialogContent({
             stored securely on your device.
           </DialogContentText>
           {state?.errors.formErrors.map((error) => (
-            <Alert key={error} severity="error" variant="filled">
-              {error}
+            <Alert key={error} variant="destructive">
+              <CircleAlert />
+              <AlertTitle>{error}</AlertTitle>
             </Alert>
           ))}
           <form
@@ -323,8 +326,9 @@ function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
   return (
     <>
       <DialogContent>
-        <Alert severity="error" variant="filled">
-          {Error.isError(error) ? `${error}` : 'An unknown error occurred'}
+        <Alert variant="destructive">
+          <CircleAlert />
+          <AlertTitle>{Error.isError(error) ? `${error}` : 'An unknown error occurred'}</AlertTitle>
         </Alert>
       </DialogContent>
       <DialogActions>
@@ -414,8 +418,9 @@ function ApiKeysDialog({
               protect your keys.
             </DialogContentText>
             {addPasskeyError && (
-              <Alert severity="error" variant="filled">
-                {addPasskeyError}
+              <Alert variant="destructive">
+                <CircleAlert />
+                <AlertTitle>{addPasskeyError}</AlertTitle>
               </Alert>
             )}
           </Stack>

--- a/app/src/app/components/ui/alert.tsx
+++ b/app/src/app/components/ui/alert.tsx
@@ -13,6 +13,8 @@ const alertVariants = cva(
           'text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current',
         warning:
           'text-warning bg-card *:data-[slot=alert-description]:text-warning/90 *:[svg]:text-current',
+        success:
+          'text-success bg-card *:data-[slot=alert-description]:text-success/90 *:[svg]:text-current',
       },
     },
     defaultVariants: {

--- a/app/src/app/dashboard/AiProviderBanner.tsx
+++ b/app/src/app/dashboard/AiProviderBanner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { TriangleAlert } from 'lucide-react';
-import { Alert, AlertAction, AlertDescription } from '#app/components/ui/alert.tsx';
+import { Alert, AlertAction, AlertDescription, AlertTitle } from '#app/components/ui/alert.tsx';
 import { Button } from '#app/components/ui/button.tsx';
 import { useApiKeysDialog } from '../ApiKeysDialogContext';
 
@@ -13,14 +13,13 @@ export function AiProviderBanner() {
   }
 
   return (
-    // pr-21 to fit button width
-    <Alert variant="warning" className="has-data-[slot=alert-action]:pr-21">
+    // pr-0 to prevent the description text from wrapping.
+    <Alert variant="warning" className="has-data-[slot=alert-action]:pr-0">
       <TriangleAlert />
-      <AlertDescription className="text-wrap">
-        No AI provider configured. Add API keys to enable document generation.
-      </AlertDescription>
+      <AlertTitle>No AI provider configured.</AlertTitle>
+      <AlertDescription>Add API keys to enable document generation.</AlertDescription>
       <AlertAction>
-        <Button variant="outline" onClick={openDialog} size="sm">
+        <Button variant="outline" size="xs" onClick={openDialog}>
           Configure
         </Button>
       </AlertAction>

--- a/app/src/app/dashboard/ProjectCards.tsx
+++ b/app/src/app/dashboard/ProjectCards.tsx
@@ -11,7 +11,8 @@ import {
 } from 'react';
 import Link from 'next/link';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-import Alert from '@mui/material/Alert';
+import { CircleAlert } from 'lucide-react';
+import { Alert, AlertTitle } from '#app/components/ui/alert.tsx';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
@@ -65,8 +66,9 @@ function DeleteConfirmDialogContent({ onClose, project, ref }: DeleteConfirmDial
             undone.
           </DialogContentText>
           {error && (
-            <Alert severity="error" variant="filled">
-              {error}
+            <Alert variant="destructive">
+              <CircleAlert />
+              <AlertTitle>{error}</AlertTitle>
             </Alert>
           )}
         </Stack>

--- a/app/src/app/dashboard/ProjectDialog.tsx
+++ b/app/src/app/dashboard/ProjectDialog.tsx
@@ -8,7 +8,8 @@ import {
   type Ref,
 } from 'react';
 import isEqual from 'react-fast-compare';
-import Alert from '@mui/material/Alert';
+import { CircleAlert, Info } from 'lucide-react';
+import { Alert, AlertTitle } from '#app/components/ui/alert.tsx';
 import Autocomplete from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -175,13 +176,15 @@ function ProjectDialogContent({
       <DialogContent>
         <Stack spacing={1}>
           {infoMessage && (
-            <Alert severity="info" variant="filled">
-              {infoMessage}
+            <Alert>
+              <Info />
+              <AlertTitle>{infoMessage}</AlertTitle>
             </Alert>
           )}
           {state?.errors.formErrors.map((error) => (
-            <Alert key={error} severity="error" variant="filled">
-              {error}
+            <Alert key={error} variant="destructive">
+              <CircleAlert />
+              <AlertTitle>{error}</AlertTitle>
             </Alert>
           ))}
           <form

--- a/app/src/app/dashboard/ProjectsErrorBoundary.tsx
+++ b/app/src/app/dashboard/ProjectsErrorBoundary.tsx
@@ -2,20 +2,20 @@
 
 import type { ReactNode } from 'react';
 import { ErrorBoundary, type FallbackProps } from 'react-error-boundary';
-import Alert from '@mui/material/Alert';
-import Button from '@mui/material/Button';
+import { CircleAlert } from 'lucide-react';
+import { Alert, AlertAction, AlertTitle } from '#app/components/ui/alert.tsx';
+import { Button } from '#app/components/ui/button.tsx';
 
 function ProjectsErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
   return (
-    <Alert
-      severity="error"
-      action={
-        <Button color="inherit" size="small" onClick={resetErrorBoundary}>
+    <Alert variant="destructive">
+      <CircleAlert />
+      <AlertTitle>{Error.isError(error) ? `${error}` : 'Failed to load projects'}</AlertTitle>
+      <AlertAction>
+        <Button variant="outline" size="xs" onClick={resetErrorBoundary}>
           Retry
         </Button>
-      }
-    >
-      {Error.isError(error) ? `${error}` : 'Failed to load projects'}
+      </AlertAction>
     </Alert>
   );
 }

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -22,6 +22,7 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-warning: var(--warning);
+  --color-success: var(--success);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -64,6 +65,7 @@
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.58 0.22 27);
   --warning: oklch(0.58 0.22 55);
+  --success: oklch(0.58 0.22 145);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -103,6 +105,7 @@
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --warning: oklch(0.704 0.191 55);
+  --success: oklch(0.704 0.191 145);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);


### PR DESCRIPTION
Supports #177

- Add `success` color token to `globals.css`
- Add `success` variant to `Alert` component
- Migrate `ApiKeysButton.tsx` from MUI `Alert` to shadcn
- Migrate `ProjectDialog.tsx` from MUI `Alert` to shadcn
- Migrate `ProjectsErrorBoundary.tsx` from MUI `Alert` to shadcn
- Migrate `ProjectCards.tsx` from MUI `Alert` to shadcn
- Update `AiProviderBanner.tsx` to use `AlertTitle` + `AlertDescription`

🤖 Generated with [Claude Code](https://claude.com/claude-code)