### PR TITLE
[app] Migrate `Project menu` to shadcn

### DIFF
--- a/app/src/app/components/ui/dropdown-menu.tsx
+++ b/app/src/app/components/ui/dropdown-menu.tsx
@@ -1,0 +1,241 @@
+import * as React from 'react';
+import { Menu as MenuPrimitive } from '@base-ui/react/menu';
+
+import { cn } from '#app/utils/cn.ts';
+import { ChevronRightIcon, CheckIcon } from 'lucide-react';
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  align = 'start',
+  alignOffset = 0,
+  side = 'bottom',
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<MenuPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset'>) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden',
+            className,
+          )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn('text-muted-foreground px-2 py-1.5 text-xs data-[inset]:pl-8', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground min-h-7 gap-2 rounded-md px-2 py-1 text-xs/relaxed [&_svg:not([class*='size-'])]:size-3.5 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground min-h-7 gap-2 rounded-md px-2 py-1 text-xs [&_svg:not([class*='size-'])]:size-3.5 flex cursor-default items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  align = 'start',
+  alignOffset = -3,
+  side = 'right',
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 w-auto',
+        className,
+      )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground min-h-7 gap-2 rounded-md py-1.5 pr-8 pl-2 text-xs [&_svg:not([class*='size-'])]:size-3.5 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center pointer-events-none"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return <MenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
+}
+
+function DropdownMenuRadioItem({ className, children, ...props }: MenuPrimitive.RadioItem.Props) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground min-h-7 gap-2 rounded-md py-1.5 pr-8 pl-2 text-xs [&_svg:not([class*='size-'])]:size-3.5 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center pointer-events-none"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuSeparator({ className, ...props }: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn('bg-border/50 -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        'text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground ml-auto text-[0.625rem] tracking-widest',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};

--- a/app/src/app/dashboard/ProjectCards.tsx
+++ b/app/src/app/dashboard/ProjectCards.tsx
@@ -10,10 +10,16 @@ import {
   type SyntheticEvent,
 } from 'react';
 import Link from 'next/link';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
-import { CircleAlert } from 'lucide-react';
+import { CircleAlert, Ellipsis } from 'lucide-react';
 import { Alert, AlertTitle } from '#app/components/ui/alert.tsx';
-import Button from '@mui/material/Button';
+import { Button } from '#app/components/ui/button.tsx';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '#app/components/ui/dropdown-menu.tsx';
+import MuiButton from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
 import CardContent from '@mui/material/CardContent';
@@ -23,9 +29,6 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import IconButton from '@mui/material/IconButton';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import { updateProject, type Project } from '../actions/project';
 import { db } from '../database';
@@ -74,10 +77,10 @@ function DeleteConfirmDialogContent({ onClose, project, ref }: DeleteConfirmDial
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button disabled={isPending} onClick={onClose}>
+        <MuiButton disabled={isPending} onClick={onClose}>
           Cancel
-        </Button>
-        <Button
+        </MuiButton>
+        <MuiButton
           color="error"
           variant="contained"
           loading={isPending}
@@ -86,7 +89,7 @@ function DeleteConfirmDialogContent({ onClose, project, ref }: DeleteConfirmDial
           }}
         >
           Delete
-        </Button>
+        </MuiButton>
       </DialogActions>
     </>
   );
@@ -123,14 +126,8 @@ type ProjectCardProps = {
 function ProjectCard({ project }: ProjectCardProps) {
   const { title, createdAt } = project;
 
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-
   function preventRipple(event: SyntheticEvent) {
     event.stopPropagation();
-  }
-
-  function handleCloseMenu() {
-    setAnchorEl(null);
   }
 
   const [editDialogOpen, setEditDialogOpen] = useState(false);
@@ -144,54 +141,62 @@ function ProjectCard({ project }: ProjectCardProps) {
   }
 
   return (
+    // TODO: Consider removing `modal={false}` after migrating to shadcn.
+    // Currently needed to avoid scroll lock conflict between Base UI and
+    // MUI's separate scroll managers.
     <>
-      <Card sx={{ height: '100%' }}>
-        <CardActionArea
-          component={Link}
-          href={`/dashboard/project/${project.id}`}
-          sx={{ height: '100%' }}
-        >
-          <Stack sx={{ height: '100%' }}>
-            <CardHeader
-              action={
-                <IconButton
-                  aria-label="Project menu"
-                  onMouseDown={preventRipple}
-                  onTouchStart={preventRipple}
-                  onClick={(event) => {
-                    // Prevent navigation
-                    event.preventDefault();
-                    setAnchorEl(event.currentTarget);
-                  }}
-                >
-                  <MoreVertIcon />
-                </IconButton>
-              }
-              title={title}
-              subheader={`Created ${dateFormatter.format(new Date(createdAt))}`}
-            />
-            <CardContent sx={{ flex: 1 }}>{/* TODO */}</CardContent>
-          </Stack>
-        </CardActionArea>
-      </Card>
-      <Menu anchorEl={anchorEl} open={!!anchorEl} onClose={handleCloseMenu}>
-        <MenuItem
-          onClick={() => {
-            handleCloseMenu();
-            setEditDialogOpen(true);
-          }}
-        >
-          Edit
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            handleCloseMenu();
-            setDeleteDialogOpen(true);
-          }}
-        >
-          Delete
-        </MenuItem>
-      </Menu>
+      <DropdownMenu modal={false}>
+        <Card sx={{ height: '100%' }}>
+          <CardActionArea
+            component={Link}
+            href={`/dashboard/project/${project.id}`}
+            sx={{ height: '100%' }}
+          >
+            <Stack sx={{ height: '100%' }}>
+              <CardHeader
+                action={
+                  <DropdownMenuTrigger
+                    render={
+                      <Button
+                        variant="ghost"
+                        size="icon-lg"
+                        aria-label="Project menu"
+                        onMouseDown={preventRipple}
+                        onTouchStart={preventRipple}
+                        onClick={(event) => {
+                          // Prevent navigation
+                          event.preventDefault();
+                        }}
+                      >
+                        <Ellipsis />
+                      </Button>
+                    }
+                  />
+                }
+                title={title}
+                subheader={`Created ${dateFormatter.format(new Date(createdAt))}`}
+              />
+              <CardContent sx={{ flex: 1 }}>{/* TODO */}</CardContent>
+            </Stack>
+          </CardActionArea>
+        </Card>
+        <DropdownMenuContent>
+          <DropdownMenuItem
+            onClick={() => {
+              setEditDialogOpen(true);
+            }}
+          >
+            Edit
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => {
+              setDeleteDialogOpen(true);
+            }}
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <ProjectDialog
         action={(estimatedDataVolume, collectionPeriod, subreddits, aiMlModelPlan, formData) =>
           updateProject(


### PR DESCRIPTION
Supports #177

## Summary
- Add `dropdown-menu` component (shadcn wrapper around Base UI `Menu`)
- Migrate Project menu from MUI (`IconButton`, `Menu`, `MenuItem`) to shadcn (`DropdownMenu`)
- Replace `MoreVertIcon` with `Ellipsis` from `lucide-react`

## Notes
- Uses `modal={false}` to avoid scroll lock conflict between Base UI and MUI's separate scroll managers (TODO to remove after full migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)