### PR TITLE
[app] Migrate 'Delete project' dialog to shadcn

### DIFF
--- a/app/src/app/components/ui/alert-dialog.tsx
+++ b/app/src/app/components/ui/alert-dialog.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import * as React from 'react';
+import { AlertDialog as AlertDialogPrimitive } from '@base-ui/react/alert-dialog';
+
+import { cn } from '#app/utils/cn.ts';
+import { Button } from '#app/components/ui/button.tsx';
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  size = 'default',
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: 'default' | 'sm';
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-3 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-64 data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        'grid grid-rows-[auto_1fr] place-items-center gap-1 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        'flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogMedia({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "bg-muted mb-2 inline-flex size-8 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        'text-sm font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        'text-muted-foreground *:[a]:hover:text-foreground text-xs/relaxed text-balance md:text-pretty *:[a]:underline *:[a]:underline-offset-3',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof Button>) {
+  return <Button data-slot="alert-dialog-action" className={cn(className)} {...props} />;
+}
+
+function AlertDialogCancel({
+  className,
+  variant = 'outline',
+  size = 'default',
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/app/src/app/dashboard/ProjectCards.tsx
+++ b/app/src/app/dashboard/ProjectCards.tsx
@@ -19,22 +19,26 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '#app/components/ui/dropdown-menu.tsx';
-import MuiButton from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
 import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
 import Stack from '@mui/material/Stack';
 import { updateProject, type Project } from '../actions/project';
 import { db } from '../database';
 import { GridItem } from './GridItem';
 import { ProjectDialog } from './ProjectDialog';
 import { useProjects } from './useProjects';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '#app/components/ui/alert-dialog.tsx';
 
 const dateFormatter = new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium' });
 
@@ -62,35 +66,31 @@ function DeleteConfirmDialogContent({ onClose, project, ref }: DeleteConfirmDial
 
   return (
     <>
-      <DialogContent>
-        <Stack spacing={1}>
-          <DialogContentText>
-            Are you sure you want to delete &ldquo;{project.title}&rdquo;? This action cannot be
-            undone.
-          </DialogContentText>
-          {error && (
-            <Alert variant="destructive">
-              <CircleAlert />
-              <AlertTitle>{error}</AlertTitle>
-            </Alert>
-          )}
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        <MuiButton disabled={isPending} onClick={onClose}>
-          Cancel
-        </MuiButton>
-        <MuiButton
-          color="error"
-          variant="contained"
+      <AlertDialogHeader>
+        <AlertDialogTitle>Delete project</AlertDialogTitle>
+        <AlertDialogDescription>
+          Are you sure you want to delete &ldquo;{project.title}&rdquo;? This action cannot be
+          undone.
+        </AlertDialogDescription>
+        {error && (
+          <Alert variant="destructive">
+            <CircleAlert />
+            <AlertTitle>{error}</AlertTitle>
+          </Alert>
+        )}
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+        <AlertDialogAction
           loading={isPending}
+          variant="destructive"
           onClick={() => {
             startTransition(action);
           }}
         >
           Delete
-        </MuiButton>
-      </DialogActions>
+        </AlertDialogAction>
+      </AlertDialogFooter>
     </>
   );
 }
@@ -103,19 +103,23 @@ function DeleteConfirmDialog({ open, onClose, project }: DeleteConfirmDialogProp
   const dialogContentRef = useRef<DeleteConfirmDialogContentHandle>(null);
 
   return (
-    <Dialog
-      maxWidth="xs"
-      open={open}
-      onClose={() => {
-        if (dialogContentRef.current?.getIsPending()) {
-          return;
-        }
-        onClose();
-      }}
-    >
-      <DialogTitle>Delete project</DialogTitle>
-      <DeleteConfirmDialogContent ref={dialogContentRef} onClose={onClose} project={project} />
-    </Dialog>
+    <>
+      <AlertDialog
+        open={open}
+        onOpenChange={(newOpen) => {
+          if (!newOpen) {
+            if (dialogContentRef.current?.getIsPending()) {
+              return;
+            }
+            onClose();
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <DeleteConfirmDialogContent ref={dialogContentRef} onClose={onClose} project={project} />
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 


### PR DESCRIPTION
Supports #177

## Summary
- Add `AlertDialog` component built on Base UI
- Migrate delete project confirmation dialog from MUI Dialog to shadcn AlertDialog
- Remove MUI Button dependency from ProjectCards.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)