### PR TITLE
[app] Migrate project dialog to shadcn

### DIFF
--- a/app/src/app/dashboard/ProjectCards.tsx
+++ b/app/src/app/dashboard/ProjectCards.tsx
@@ -145,11 +145,8 @@ function ProjectCard({ project }: ProjectCardProps) {
   }
 
   return (
-    // TODO: Consider removing `modal={false}` after migrating to shadcn.
-    // Currently needed to avoid scroll lock conflict between Base UI and
-    // MUI's separate scroll managers.
     <>
-      <DropdownMenu modal={false}>
+      <DropdownMenu>
         <Card sx={{ height: '100%' }}>
           <CardActionArea
             component={Link}

--- a/app/src/app/dashboard/ProjectDialog.tsx
+++ b/app/src/app/dashboard/ProjectDialog.tsx
@@ -10,12 +10,7 @@ import {
 import isEqual from 'react-fast-compare';
 import { CircleAlert, Info } from 'lucide-react';
 import Autocomplete from '@mui/material/Autocomplete';
-import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
 import FormControl from '@mui/material/FormControl';
 import FormHelperText from '@mui/material/FormHelperText';
 import InputLabel from '@mui/material/InputLabel';
@@ -24,6 +19,16 @@ import Select from '@mui/material/Select';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import { Alert, AlertTitle } from '#app/components/ui/alert.tsx';
+import { Button } from '#app/components/ui/button.tsx';
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '#app/components/ui/dialog.tsx';
 import {
   AI_ML_MODEL_PLAN_OPTIONS,
   collectionPeriodSchema,
@@ -173,7 +178,7 @@ function ProjectDialogContent({
 
   return (
     <>
-      <DialogContent>
+      <DialogBody>
         <Stack spacing={1}>
           {infoMessage && (
             <Alert>
@@ -406,15 +411,15 @@ function ProjectDialogContent({
             </Stack>
           </form>
         </Stack>
-      </DialogContent>
-      <DialogActions>
-        <Button disabled={isPending} onClick={onClose}>
+      </DialogBody>
+      <DialogFooter>
+        <DialogClose disabled={isPending} render={<Button variant="outline" />}>
           Cancel
-        </Button>
-        <Button type="submit" form={formId} variant="contained" loading={isPending}>
+        </DialogClose>
+        <Button type="submit" form={formId} loading={isPending}>
           {submitLabel}
         </Button>
-      </DialogActions>
+      </DialogFooter>
     </>
   );
 }
@@ -437,24 +442,29 @@ export function ProjectDialog({
 
   return (
     <Dialog
-      fullWidth
       open={open}
-      onClose={() => {
-        if (dialogContentRef.current?.getIsPending()) {
-          return;
+      onOpenChange={(newOpen) => {
+        if (!newOpen) {
+          if (dialogContentRef.current?.getIsPending()) {
+            return;
+          }
+          onClose();
         }
-        onClose();
       }}
     >
-      <DialogTitle>{title}</DialogTitle>
-      <ProjectDialogContent
-        ref={dialogContentRef}
-        action={action}
-        initialProject={initialProject}
-        infoMessage={infoMessage}
-        onClose={onClose}
-        submitLabel={submitLabel}
-      />
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <ProjectDialogContent
+          ref={dialogContentRef}
+          action={action}
+          initialProject={initialProject}
+          infoMessage={infoMessage}
+          onClose={onClose}
+          submitLabel={submitLabel}
+        />
+      </DialogContent>
     </Dialog>
   );
 }


### PR DESCRIPTION
Supports #177.

## Summary
- Migrate `ProjectDialog` from MUI Dialog to shadcn Dialog
- Replace MUI Button with shadcn Button in the dialog footer  
- Remove the `modal={false}` workaround from DropdownMenu

## Test plan
- [x] Creating a new project works correctly
- [x] Editing an existing project works correctly
- [x] Dialog closes properly when clicking Cancel or outside
- [x] Form validation errors display correctly
- [x] Loading state works when submitting
