### PR TITLE
[app] Remove MUI's z-index scale

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -83,9 +83,6 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-
-  /* z-index scale matching MUI */
-  --z-index-app-header: 1100;
 }
 
 .dark {

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
 
 function AppHeader() {
   return (
-    <header className="sticky top-0 z-(--z-index-app-header) border-b bg-background">
+    <header className="sticky top-0 z-50 border-b bg-background">
       <div className="flex h-12 px-4">
         <div className="flex flex-1 items-center gap-4">
           <span className="text-xl font-medium">RedditHarbor</span>


### PR DESCRIPTION
Supports #177. This is because 1100 was making the app header appear above shadcn dialogs. If we find in the future that we'd benefit from having a global z-index scale, we can reintroduce it then.