### PR TITLE
[app] Add scrollable dialog support

### DIFF
--- a/app/src/app/components/ui/dialog.tsx
+++ b/app/src/app/components/ui/dialog.tsx
@@ -50,7 +50,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+          'bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 flex flex-col max-h-[calc(100%-2rem)] max-w-[calc(100%-2rem)] gap-4 overflow-y-auto rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none',
           className,
         )}
         {...props}
@@ -70,6 +70,10 @@ function DialogContent({
   );
 }
 
+function DialogBody({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div className={cn('overflow-y-auto pb-4', className)} {...props} />;
+}
+
 function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div data-slot="dialog-header" className={cn('gap-1 flex flex-col', className)} {...props} />
@@ -87,7 +91,7 @@ function DialogFooter({
   return (
     <div
       data-slot="dialog-footer"
-      className={cn('gap-2 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      className={cn('gap-2 flex flex-col-reverse sm:flex-row sm:justify-end', className)}
       {...props}
     >
       {children}
@@ -123,6 +127,7 @@ function DialogDescription({ className, ...props }: DialogPrimitive.Description.
 
 export {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,


### PR DESCRIPTION
## Summary

- Add `max-h-[calc(100%-2rem)]` and `overflow-y-auto` to `DialogContent` for viewport-constrained scrolling
- Switch from `grid` to `flex flex-col` layout (flex naturally constrains children within max-height, while grid expands to fit content)
- Add new `DialogBody` component with `overflow-y-auto pb-4` for scrollable content area
- Fix duplicate `gap-2` in `DialogFooter`

## Behaviour

- **Normal viewport**: Body scrolls, header/footer stay pinned
- **Tiny viewport**: Entire dialog scrolls so user can reach all elements
- **Short content**: Dialog shrinks to fit (doesn't expand to max-height)

Supports #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)