### PR TITLE
[app] Fix dialog scrollbar overlapping content

### DIFF
--- a/app/src/app/components/ui/dialog.tsx
+++ b/app/src/app/components/ui/dialog.tsx
@@ -50,7 +50,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 flex flex-col max-h-[calc(100%-2rem)] max-w-[calc(100%-2rem)] gap-4 overflow-y-auto rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none',
+          'bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 flex flex-col max-h-[calc(100%-2rem)] max-w-[calc(100%-2rem)] gap-4 overflow-y-auto rounded-xl py-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none',
           className,
         )}
         {...props}
@@ -71,12 +71,16 @@ function DialogContent({
 }
 
 function DialogBody({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div className={cn('overflow-y-auto pb-4', className)} {...props} />;
+  return <div className={cn('overflow-y-auto px-4 pb-4', className)} {...props} />;
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <div data-slot="dialog-header" className={cn('gap-2 flex flex-col', className)} {...props} />
+    <div
+      data-slot="dialog-header"
+      className={cn('gap-2 flex flex-col px-4', className)}
+      {...props}
+    />
   );
 }
 
@@ -91,7 +95,7 @@ function DialogFooter({
   return (
     <div
       data-slot="dialog-footer"
-      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      className={cn('flex flex-col-reverse gap-2 px-4 sm:flex-row sm:justify-end', className)}
       {...props}
     >
       {children}


### PR DESCRIPTION
Move horizontal padding from `DialogContent` to `DialogHeader`, `DialogBody`, and `DialogFooter`. This mirrors MUI's approach where the scrollbar appears at the container edge while content is padded away from it.

Supports #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)