### PR TITLE
[app] Migrate to shadcn `Card`

### DIFF
--- a/app/src/app/dashboard/ProjectCards.tsx
+++ b/app/src/app/dashboard/ProjectCards.tsx
@@ -7,15 +7,9 @@ import {
   useRef,
   useState,
   type Ref,
-  type SyntheticEvent,
 } from 'react';
 import Link from 'next/link';
 import { CircleAlert, Ellipsis } from 'lucide-react';
-import Card from '@mui/material/Card';
-import CardActionArea from '@mui/material/CardActionArea';
-import CardContent from '@mui/material/CardContent';
-import CardHeader from '@mui/material/CardHeader';
-import Stack from '@mui/material/Stack';
 import { Alert, AlertTitle } from '#app/components/ui/alert.tsx';
 import {
   AlertDialog,
@@ -28,6 +22,14 @@ import {
   AlertDialogTitle,
 } from '#app/components/ui/alert-dialog.tsx';
 import { Button } from '#app/components/ui/button.tsx';
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '#app/components/ui/card.tsx';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -130,10 +132,6 @@ type ProjectCardProps = {
 function ProjectCard({ project }: ProjectCardProps) {
   const { title, createdAt } = project;
 
-  function preventRipple(event: SyntheticEvent) {
-    event.stopPropagation();
-  }
-
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   function handleCloseEditDialog() {
     setEditDialogOpen(false);
@@ -147,39 +145,32 @@ function ProjectCard({ project }: ProjectCardProps) {
   return (
     <>
       <DropdownMenu>
-        <Card sx={{ height: '100%' }}>
-          <CardActionArea
-            component={Link}
-            href={`/dashboard/project/${project.id}`}
-            sx={{ height: '100%' }}
-          >
-            <Stack sx={{ height: '100%' }}>
-              <CardHeader
-                action={
-                  <DropdownMenuTrigger
-                    render={
-                      <Button
-                        variant="ghost"
-                        size="icon-lg"
-                        aria-label="Project menu"
-                        onMouseDown={preventRipple}
-                        onTouchStart={preventRipple}
-                        onClick={(event) => {
-                          // Prevent navigation
-                          event.preventDefault();
-                        }}
-                      >
-                        <Ellipsis />
-                      </Button>
-                    }
-                  />
+        <Card
+          render={<Link href={`/dashboard/project/${project.id}`} />}
+          className="h-full hover:outline hover:outline-offset-1 hover:outline-auto focus-visible:outline focus-visible:outline-offset-1 focus-visible:outline-auto"
+        >
+          <CardHeader>
+            <CardTitle>{title}</CardTitle>
+            <CardDescription>Created {dateFormatter.format(new Date(createdAt))}</CardDescription>
+            <CardAction>
+              <DropdownMenuTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-lg"
+                    aria-label="Project menu"
+                    onClick={(event) => {
+                      // Prevent navigation
+                      event.preventDefault();
+                    }}
+                  >
+                    <Ellipsis />
+                  </Button>
                 }
-                title={title}
-                subheader={`Created ${dateFormatter.format(new Date(createdAt))}`}
               />
-              <CardContent sx={{ flex: 1 }}>{/* TODO */}</CardContent>
-            </Stack>
-          </CardActionArea>
+            </CardAction>
+          </CardHeader>
+          <CardContent>{/* TODO */}</CardContent>
         </Card>
         <DropdownMenuContent>
           <DropdownMenuItem

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -136,3 +136,7 @@
     cursor: pointer;
   }
 }
+
+@utility outline-auto {
+  outline-style: auto;
+}


### PR DESCRIPTION
## Summary

Migrate dashboard project cards from MUI to shadcn. Supports #177.

### Changes

**1. MUI → shadcn Card migration (ProjectCards)**

| MUI Component | Replacement | Notes |
|---------------|-------------|-------|
| `Card` | shadcn `Card` | Uses `useRender` for polymorphic rendering |
| `CardActionArea` | `render` prop | Card renders as `<Link>` directly |
| `CardHeader` | shadcn `CardHeader` | Restructured to use slot-based children |
| `CardHeader.title` | `CardTitle` | Separate component instead of prop |
| `CardHeader.subheader` | `CardDescription` | Separate component instead of prop |
| `CardHeader.action` | `CardAction` | Separate component instead of prop |
| `CardContent` | shadcn `CardContent` | Direct replacement |
| `Stack` | Removed | Card already has flex-col in base styles |

**2. MUI sx props → Tailwind classes**

| MUI `sx` prop | Tailwind class | Purpose |
|---------------|----------------|---------|
| `height: '100%'` | `h-full` | Full height cards |

**3. Add `render` prop to Card**

Added polymorphic rendering support via Base UI's `useRender` hook. This replaces MUI's `CardActionArea component={Link}` pattern.

```tsx
// MUI approach
<Card>
  <CardActionArea component={Link} href="/path">
    ...
  </CardActionArea>
</Card>

// shadcn approach with render prop
<Card render={<Link href="/path" />}>
  ...
</Card>
```

**4. Hover and focus styles**

MUI's `CardActionArea` provides built-in ripple and hover effects. We add explicit outline styles for hover and focus:

```tsx
className="hover:outline hover:outline-offset-1 hover:outline-auto focus-visible:outline focus-visible:outline-offset-1 focus-visible:outline-auto"
```

Added `@utility outline-auto` to globals.css for the `outline-style: auto` property.

**5. Ripple prevention → simplified**

MUI required `onMouseDown` and `onTouchStart` handlers with `stopPropagation()` to prevent ripple effects when clicking nested buttons. With shadcn, we only need `onClick` with `preventDefault()`:

```tsx
// MUI - needed to prevent ripple
onMouseDown={preventRipple}
onTouchStart={preventRipple}
onClick={(e) => e.preventDefault()}

// shadcn - just prevent navigation
onClick={(e) => e.preventDefault())
```

## Test plan

- [ ] ProjectCard shows outline on hover
- [ ] ProjectCard shows outline on keyboard focus
- [ ] Dropdown menu button still works and prevents card navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)