### PR TITLE
[app] Remove unused `outline-auto` utility class

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -136,7 +136,3 @@
     cursor: pointer;
   }
 }
-
-@utility outline-auto {
-  outline-style: auto;
-}


### PR DESCRIPTION
This utility was added in #210 but is no longer used.