### PR TITLE
[app] Add `FieldIdContext` for automatic label-input wiring

### DIFF
--- a/app/src/app/components/ui/field.tsx
+++ b/app/src/app/components/ui/field.tsx
@@ -1,10 +1,17 @@
 'use client';
 
+import { createContext, use, useId } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '#app/utils/cn.ts';
 import { Label } from '#app/components/ui/label.tsx';
 import { Separator } from '#app/components/ui/separator.tsx';
+
+const FieldIdContext = createContext<string | undefined>(undefined);
+
+export function useFieldId() {
+  return use(FieldIdContext);
+}
 
 function FieldSet({ className, ...props }: React.ComponentProps<'fieldset'>) {
   return (
@@ -70,14 +77,18 @@ function Field({
   orientation = 'vertical',
   ...props
 }: React.ComponentProps<'div'> & VariantProps<typeof fieldVariants>) {
+  const id = useId();
+
   return (
-    <div
-      role="group"
-      data-slot="field"
-      data-orientation={orientation}
-      className={cn(fieldVariants({ orientation }), className)}
-      {...props}
-    />
+    <FieldIdContext value={id}>
+      <div
+        role="group"
+        data-slot="field"
+        data-orientation={orientation}
+        className={cn(fieldVariants({ orientation }), className)}
+        {...props}
+      />
+    </FieldIdContext>
   );
 }
 
@@ -91,10 +102,13 @@ function FieldContent({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function FieldLabel({ className, ...props }: React.ComponentProps<typeof Label>) {
+function FieldLabel({ className, htmlFor, ...props }: React.ComponentProps<typeof Label>) {
+  const fieldId = useFieldId();
+
   return (
     <Label
       data-slot="field-label"
+      htmlFor={htmlFor ?? fieldId}
       className={cn(
         'has-data-checked:bg-primary/5 has-data-checked:border-primary dark:has-data-checked:bg-primary/10 gap-2 group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-2.5 group/field-label peer/field-label flex w-fit leading-snug',
         'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col',

--- a/app/src/app/components/ui/input.tsx
+++ b/app/src/app/components/ui/input.tsx
@@ -1,12 +1,18 @@
+'use client';
+
 import type * as React from 'react';
 import { Input as InputPrimitive } from '@base-ui/react/input';
 
 import { cn } from '#app/utils/cn.ts';
+import { useFieldId } from '#app/components/ui/field.tsx';
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+function Input({ className, id, type, ...props }: React.ComponentProps<'input'>) {
+  const fieldId = useFieldId();
+
   return (
     <InputPrimitive
       type={type}
+      id={id ?? fieldId}
       data-slot="input"
       className={cn(
         'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',

--- a/app/src/app/components/ui/textarea.tsx
+++ b/app/src/app/components/ui/textarea.tsx
@@ -1,10 +1,16 @@
+'use client';
+
 import type * as React from 'react';
 
 import { cn } from '#app/utils/cn.ts';
+import { useFieldId } from '#app/components/ui/field.tsx';
 
-function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+function Textarea({ className, id, ...props }: React.ComponentProps<'textarea'>) {
+  const fieldId = useFieldId();
+
   return (
     <textarea
+      id={id ?? fieldId}
       data-slot="textarea"
       className={cn(
         'border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50',


### PR DESCRIPTION
## Summary

- Add `FieldIdContext` that provides an auto-generated ID from `useId()`
- `Field` component provides the context to its children
- `FieldLabel` automatically sets `htmlFor` from context
- `Input` and `Textarea` automatically set `id` from context via `useFieldId()`

Supports #177, #227.

## Usage

Labels and inputs are now automatically wired when wrapped in a `Field`:

```tsx
<Field>
  <FieldLabel>Email</FieldLabel>
  <Input placeholder="Enter email" />
</Field>
```

Explicit `htmlFor`/`id` props still work as overrides when needed.

## Test plan

- [ ] Verify clicking a label focuses its associated input
- [ ] Verify explicit `id`/`htmlFor` props override the context values