### PR TITLE
[app] Refactor `FieldIdContext` to `FieldContext`

### DIFF
--- a/app/src/app/components/ui/field.tsx
+++ b/app/src/app/components/ui/field.tsx
@@ -7,10 +7,14 @@ import { cn } from '#app/utils/cn.ts';
 import { Label } from '#app/components/ui/label.tsx';
 import { Separator } from '#app/components/ui/separator.tsx';
 
-const FieldIdContext = createContext<string | undefined>(undefined);
+type FieldContextValue = {
+  id: string;
+};
 
-export function useFieldId() {
-  return use(FieldIdContext);
+const FieldContext = createContext<FieldContextValue | undefined>(undefined);
+
+export function useFieldContext() {
+  return use(FieldContext);
 }
 
 function FieldSet({ className, ...props }: React.ComponentProps<'fieldset'>) {
@@ -80,7 +84,7 @@ function Field({
   const id = useId();
 
   return (
-    <FieldIdContext value={id}>
+    <FieldContext value={{ id }}>
       <div
         role="group"
         data-slot="field"
@@ -88,7 +92,7 @@ function Field({
         className={cn(fieldVariants({ orientation }), className)}
         {...props}
       />
-    </FieldIdContext>
+    </FieldContext>
   );
 }
 
@@ -103,12 +107,12 @@ function FieldContent({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 function FieldLabel({ className, htmlFor, ...props }: React.ComponentProps<typeof Label>) {
-  const fieldId = useFieldId();
+  const fieldContext = useFieldContext();
 
   return (
     <Label
       data-slot="field-label"
-      htmlFor={htmlFor ?? fieldId}
+      htmlFor={htmlFor ?? fieldContext?.id}
       className={cn(
         'has-data-checked:bg-primary/5 has-data-checked:border-primary dark:has-data-checked:bg-primary/10 gap-2 group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-2.5 group/field-label peer/field-label flex w-fit leading-snug',
         'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col',

--- a/app/src/app/components/ui/input.tsx
+++ b/app/src/app/components/ui/input.tsx
@@ -4,15 +4,15 @@ import type * as React from 'react';
 import { Input as InputPrimitive } from '@base-ui/react/input';
 
 import { cn } from '#app/utils/cn.ts';
-import { useFieldId } from '#app/components/ui/field.tsx';
+import { useFieldContext } from '#app/components/ui/field.tsx';
 
 function Input({ className, id, type, ...props }: React.ComponentProps<'input'>) {
-  const fieldId = useFieldId();
+  const fieldContext = useFieldContext();
 
   return (
     <InputPrimitive
       type={type}
-      id={id ?? fieldId}
+      id={id ?? fieldContext?.id}
       data-slot="input"
       className={cn(
         'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',

--- a/app/src/app/components/ui/textarea.tsx
+++ b/app/src/app/components/ui/textarea.tsx
@@ -3,14 +3,14 @@
 import type * as React from 'react';
 
 import { cn } from '#app/utils/cn.ts';
-import { useFieldId } from '#app/components/ui/field.tsx';
+import { useFieldContext } from '#app/components/ui/field.tsx';
 
 function Textarea({ className, id, ...props }: React.ComponentProps<'textarea'>) {
-  const fieldId = useFieldId();
+  const fieldContext = useFieldContext();
 
   return (
     <textarea
-      id={id ?? fieldId}
+      id={id ?? fieldContext?.id}
       data-slot="textarea"
       className={cn(
         'border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50',


### PR DESCRIPTION
## Summary
- Rename `FieldIdContext` to `FieldContext` with an object value type
- Prepare context structure for future additions (e.g., `required`)
- Update `useFieldId` to `useFieldContext` across `field.tsx`, `input.tsx`, and `textarea.tsx`

## Test plan
- [ ] Verify field labels still receive correct `htmlFor` attributes
- [ ] Verify inputs/textareas still receive correct `id` attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)