### PR TITLE
[app] Add `required` prop to `Field` component

### DIFF
--- a/app/src/app/components/ui/field.tsx
+++ b/app/src/app/components/ui/field.tsx
@@ -9,6 +9,7 @@ import { Separator } from '#app/components/ui/separator.tsx';
 
 type FieldContextValue = {
   id: string;
+  required: boolean;
 };
 
 const FieldContext = createContext<FieldContextValue | undefined>(undefined);
@@ -79,12 +80,13 @@ const fieldVariants = cva('data-[invalid=true]:text-destructive gap-2 group/fiel
 function Field({
   className,
   orientation = 'vertical',
+  required = false,
   ...props
-}: React.ComponentProps<'div'> & VariantProps<typeof fieldVariants>) {
+}: React.ComponentProps<'div'> & VariantProps<typeof fieldVariants> & { required?: boolean }) {
   const id = useId();
 
   return (
-    <FieldContext value={{ id }}>
+    <FieldContext value={{ id, required }}>
       <div
         role="group"
         data-slot="field"
@@ -106,7 +108,12 @@ function FieldContent({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function FieldLabel({ className, htmlFor, ...props }: React.ComponentProps<typeof Label>) {
+function FieldLabel({
+  children,
+  className,
+  htmlFor,
+  ...props
+}: React.ComponentProps<typeof Label>) {
   const fieldContext = useFieldContext();
 
   return (
@@ -119,7 +126,18 @@ function FieldLabel({ className, htmlFor, ...props }: React.ComponentProps<typeo
         className,
       )}
       {...props}
-    />
+    >
+      {fieldContext?.required ? (
+        <>
+          {children}
+          <span className="text-destructive" aria-hidden>
+            *
+          </span>
+        </>
+      ) : (
+        children
+      )}
+    </Label>
   );
 }
 

--- a/app/src/app/components/ui/input.tsx
+++ b/app/src/app/components/ui/input.tsx
@@ -6,13 +6,14 @@ import { Input as InputPrimitive } from '@base-ui/react/input';
 import { cn } from '#app/utils/cn.ts';
 import { useFieldContext } from '#app/components/ui/field.tsx';
 
-function Input({ className, id, type, ...props }: React.ComponentProps<'input'>) {
+function Input({ className, id, required, type, ...props }: React.ComponentProps<'input'>) {
   const fieldContext = useFieldContext();
 
   return (
     <InputPrimitive
       type={type}
       id={id ?? fieldContext?.id}
+      required={required ?? fieldContext?.required}
       data-slot="input"
       className={cn(
         'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',

--- a/app/src/app/components/ui/textarea.tsx
+++ b/app/src/app/components/ui/textarea.tsx
@@ -5,12 +5,13 @@ import type * as React from 'react';
 import { cn } from '#app/utils/cn.ts';
 import { useFieldContext } from '#app/components/ui/field.tsx';
 
-function Textarea({ className, id, ...props }: React.ComponentProps<'textarea'>) {
+function Textarea({ className, id, required, ...props }: React.ComponentProps<'textarea'>) {
   const fieldContext = useFieldContext();
 
   return (
     <textarea
       id={id ?? fieldContext?.id}
+      required={required ?? fieldContext?.required}
       data-slot="textarea"
       className={cn(
         'border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50',


### PR DESCRIPTION
## Summary
- Add `required` prop to `Field` component that flows through `FieldContext`
- `FieldLabel` automatically displays a red asterisk when field is required
- `Input` and `Textarea` automatically inherit `required` attribute from context (can override with prop)
- Uses `aria-hidden` on asterisk for accessibility (screen readers announce required via input attribute)

Supports #177

## Usage
```tsx
<Field required>
  <FieldLabel>Email</FieldLabel>
  <Input />
</Field>
```

<img width="385" height="126" alt="image" src="https://github.com/user-attachments/assets/74fc6fae-e3ce-41eb-9336-2826aa517bdb" />


## Test plan
- [ ] Verify asterisk appears on required fields
- [ ] Verify asterisk does not appear on non-required fields
- [ ] Verify asterisk styling matches destructive color
- [ ] Verify inputs have `required` attribute when field is required

🤖 Generated with [Claude Code](https://claude.com/claude-code)