### PR TITLE
[app] Derive `Input` key from `defaultValue` internally

### DIFF
--- a/app/src/app/ApiKeysButton.tsx
+++ b/app/src/app/ApiKeysButton.tsx
@@ -213,7 +213,6 @@ function ApiKeysDialogContent({
               <Field>
                 <FieldLabel>Reddit client ID</FieldLabel>
                 <Input
-                  key={apiKeys.redditClientId}
                   name={'redditClientId' satisfies keyof ApiKeys}
                   defaultValue={apiKeys.redditClientId}
                 />
@@ -229,7 +228,6 @@ function ApiKeysDialogContent({
               <Field data-invalid={!!state?.errors.fieldErrors.supabaseProjectUrl?.length}>
                 <FieldLabel>Supabase project URL</FieldLabel>
                 <Input
-                  key={apiKeys.supabaseProjectUrl}
                   name={'supabaseProjectUrl' satisfies keyof ApiKeys}
                   placeholder="https://your-project.supabase.co"
                   type="url"

--- a/app/src/app/components/ui/PasswordInput.tsx
+++ b/app/src/app/components/ui/PasswordInput.tsx
@@ -8,21 +8,11 @@ import {
   InputGroupInput,
 } from '#app/components/ui/input-group.tsx';
 
-export function PasswordInput({
-  defaultValue,
-  ...rest
-}: Omit<ComponentProps<'input'>, 'type'> & {
-  defaultValue?: string;
-}) {
+export function PasswordInput(props: Omit<ComponentProps<'input'>, 'type'>) {
   const [isVisible, setIsVisible] = useState(false);
   return (
     <InputGroup>
-      <InputGroupInput
-        key={defaultValue}
-        defaultValue={defaultValue}
-        type={isVisible ? 'text' : 'password'}
-        {...rest}
-      />
+      <InputGroupInput {...props} type={isVisible ? 'text' : 'password'} />
       <InputGroupAddon align="inline-end">
         <InputGroupButton
           size="icon-xs"

--- a/app/src/app/components/ui/input.tsx
+++ b/app/src/app/components/ui/input.tsx
@@ -1,19 +1,28 @@
 'use client';
 
-import type * as React from 'react';
+import type { ComponentProps, Key } from 'react';
 import { Input as InputPrimitive } from '@base-ui/react/input';
 
 import { cn } from '#app/utils/cn.ts';
 import { useFieldContext } from '#app/components/ui/field.tsx';
 
-function Input({ className, id, required, type, ...props }: React.ComponentProps<'input'>) {
+function Input({ className, defaultValue, id, required, type, ...props }: ComponentProps<'input'>) {
   const fieldContext = useFieldContext();
+
+  let key: Key | undefined;
+  if (typeof defaultValue === 'string' || typeof defaultValue === 'number') {
+    key = defaultValue;
+  } else if (Array.isArray(defaultValue)) {
+    key = defaultValue.join(',');
+  }
 
   return (
     <InputPrimitive
+      key={key}
       type={type}
       id={id ?? fieldContext?.id}
       required={required ?? fieldContext?.required}
+      defaultValue={defaultValue}
       data-slot="input"
       className={cn(
         'dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',

--- a/app/src/app/dashboard/ProjectDialog.tsx
+++ b/app/src/app/dashboard/ProjectDialog.tsx
@@ -206,7 +206,6 @@ function ProjectDialogContent({
             <Field required data-invalid={!!state?.errors.fieldErrors.title?.length}>
               <FieldLabel>Project title</FieldLabel>
               <Input
-                key={initialProject.title}
                 name={'title' satisfies keyof ProjectInput}
                 defaultValue={initialProject.title}
                 placeholder="Political Discourse Analysis 2024"
@@ -396,7 +395,6 @@ function ProjectDialogContent({
               >
                 <FieldLabel>Principal investigator</FieldLabel>
                 <Input
-                  key={initialProject.principalInvestigator}
                   name={'principalInvestigator' satisfies keyof ProjectInput}
                   defaultValue={initialProject.principalInvestigator}
                   placeholder="Full name"
@@ -411,7 +409,6 @@ function ProjectDialogContent({
               <Field required data-invalid={!!state?.errors.fieldErrors.institution?.length}>
                 <FieldLabel>Institution</FieldLabel>
                 <Input
-                  key={initialProject.institution}
                   name={'institution' satisfies keyof ProjectInput}
                   defaultValue={initialProject.institution}
                   placeholder="University or organisation"


### PR DESCRIPTION
Input component now automatically derives its `key` from `defaultValue`, removing the need for manual `key` props at call sites.

This ensures uncontrolled inputs reset properly when their default value changes.