### PR TITLE
[app] Migrate AI/ML model plans `Select` to shadcn

### DIFF
--- a/app/src/app/actions/project.ts
+++ b/app/src/app/actions/project.ts
@@ -55,7 +55,6 @@ export async function createProject(
   estimatedDataVolume: EstimatedDataVolume | null,
   collectionPeriod: CollectionPeriod | null,
   subreddits: string[],
-  aiMlModelPlan: AiMlModelPlan | null,
   formData: FormData,
 ): Promise<ProjectFormState | undefined> {
   const rawFormData = {
@@ -63,7 +62,6 @@ export async function createProject(
     estimatedDataVolume,
     collectionPeriod,
     subreddits,
-    aiMlModelPlan,
   };
   const parsedResult = projectInputSchema.safeParse(rawFormData);
 
@@ -98,7 +96,6 @@ export async function updateProject(
   estimatedDataVolume: EstimatedDataVolume | null,
   collectionPeriod: CollectionPeriod | null,
   subreddits: string[],
-  aiMlModelPlan: AiMlModelPlan | null,
   formData: FormData,
 ): Promise<ProjectFormState | undefined> {
   const rawFormData = {
@@ -106,7 +103,6 @@ export async function updateProject(
     estimatedDataVolume,
     collectionPeriod,
     subreddits,
-    aiMlModelPlan,
   };
   const parsedResult = projectInputSchema.safeParse(rawFormData);
 

--- a/app/src/app/dashboard/NewProjectButton.tsx
+++ b/app/src/app/dashboard/NewProjectButton.tsx
@@ -24,8 +24,8 @@ export function NewProjectButton() {
         New project
       </Button>
       <ProjectDialog
-        action={(estimatedDataVolume, collectionPeriod, subreddits, aiMlModelPlan, formData) =>
-          createProject(estimatedDataVolume, collectionPeriod, subreddits, aiMlModelPlan, formData)
+        action={(estimatedDataVolume, collectionPeriod, subreddits, formData) =>
+          createProject(estimatedDataVolume, collectionPeriod, subreddits, formData)
         }
         infoMessage="This information initialises your DPIA and will flow through all PETLP phases."
         open={open}

--- a/app/src/app/dashboard/ProjectCards.tsx
+++ b/app/src/app/dashboard/ProjectCards.tsx
@@ -190,15 +190,8 @@ function ProjectCard({ project }: ProjectCardProps) {
         </DropdownMenuContent>
       </DropdownMenu>
       <ProjectDialog
-        action={(estimatedDataVolume, collectionPeriod, subreddits, aiMlModelPlan, formData) =>
-          updateProject(
-            project,
-            estimatedDataVolume,
-            collectionPeriod,
-            subreddits,
-            aiMlModelPlan,
-            formData,
-          )
+        action={(estimatedDataVolume, collectionPeriod, subreddits, formData) =>
+          updateProject(project, estimatedDataVolume, collectionPeriod, subreddits, formData)
         }
         initialProject={project}
         open={editDialogOpen}

--- a/app/src/app/dashboard/ProjectDialog.tsx
+++ b/app/src/app/dashboard/ProjectDialog.tsx
@@ -36,6 +36,14 @@ import {
   FieldLabel,
 } from '#app/components/ui/field.tsx';
 import { Input } from '#app/components/ui/input.tsx';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '#app/components/ui/select.tsx';
 import { Textarea } from '#app/components/ui/textarea.tsx';
 import {
   AI_ML_MODEL_PLAN_OPTIONS,
@@ -95,6 +103,14 @@ const AI_ML_MODEL_PLAN_LABELS: Record<AiMlModelPlan, string> = {
   customDeepLearning: 'Custom deep learning',
 };
 
+const AI_ML_MODEL_PLAN_ITEMS: { label: string; value: AiMlModelPlan | null }[] = [
+  { label: 'Select AI/ML model plan', value: null },
+  ...AI_ML_MODEL_PLAN_OPTIONS.map((option) => ({
+    label: AI_ML_MODEL_PLAN_LABELS[option],
+    value: option,
+  })),
+];
+
 function normaliseSubreddit(value: string): string {
   // Remove `r/` prefix and trim whitespace.
   return value.replace(/^r\//, '').trim();
@@ -127,7 +143,6 @@ type ProjectDialogContentProps = {
     estimatedDataVolume: EstimatedDataVolume | null,
     collectionPeriod: CollectionPeriod | null,
     subreddits: string[],
-    aiMlModelPlan: AiMlModelPlan | null,
     formData: FormData,
   ) => Promise<ProjectFormState | undefined>;
   initialProject?: InitialProject;
@@ -148,7 +163,6 @@ function ProjectDialogContent({
   const formId = useId();
   const dataVolumeLabelId = useId();
   const collectionPeriodLabelId = useId();
-  const aiMlModelPlanLabelId = useId();
   const [researchObjectiveLength, setResearchObjectiveLength] = useState(
     initialProject.researchObjective.length,
   );
@@ -157,16 +171,9 @@ function ProjectDialogContent({
     initialProject.estimatedDataVolume,
   );
   const [collectionPeriod, setCollectionPeriod] = useState(initialProject.collectionPeriod);
-  const [aiMlModelPlan, setAiMlModelPlan] = useState(initialProject.aiMlModelPlan);
 
   async function submitAction(_prevState: ProjectFormState | undefined, formData: FormData) {
-    const result = await actionProp(
-      estimatedDataVolume,
-      collectionPeriod,
-      subreddits,
-      aiMlModelPlan,
-      formData,
-    );
+    const result = await actionProp(estimatedDataVolume, collectionPeriod, subreddits, formData);
     if (!result?.errors) {
       onClose();
     }
@@ -378,33 +385,40 @@ function ProjectDialogContent({
                   />
                 )}
               />
-              <FormControl
-                required
-                error={!!state?.errors.fieldErrors.aiMlModelPlan?.length}
-                margin="dense"
-                size="small"
-                fullWidth
-              >
-                <InputLabel id={aiMlModelPlanLabelId}>AI/ML model plans</InputLabel>
-                <MuiSelect
-                  labelId={aiMlModelPlanLabelId}
-                  label="AI/ML model plans"
-                  value={aiMlModelPlan ?? ''}
-                  onChange={(event) => {
-                    setAiMlModelPlan(event.target.value);
-                  }}
+              <Field required data-invalid={!!state?.errors.fieldErrors.aiMlModelPlan?.length}>
+                <FieldLabel>AI/ML model plans</FieldLabel>
+                <Select
+                  key={initialProject.aiMlModelPlan}
+                  name={'aiMlModelPlan' satisfies keyof ProjectInput}
+                  defaultValue={initialProject.aiMlModelPlan}
+                  items={AI_ML_MODEL_PLAN_ITEMS}
+                  required
                 >
-                  {AI_ML_MODEL_PLAN_OPTIONS.map((option) => (
-                    <MenuItem key={option} value={option}>
-                      {AI_ML_MODEL_PLAN_LABELS[option]}
-                    </MenuItem>
-                  ))}
-                </MuiSelect>
-                <FormHelperText>
-                  {state?.errors.fieldErrors.aiMlModelPlan?.[0] ??
-                    'This helps determine privacy safeguards needed'}
-                </FormHelperText>
-              </FormControl>
+                  <SelectTrigger aria-invalid={!!state?.errors.fieldErrors.aiMlModelPlan?.length}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {AI_ML_MODEL_PLAN_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {AI_ML_MODEL_PLAN_LABELS[option]}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                {state?.errors.fieldErrors.aiMlModelPlan?.length ? (
+                  <FieldError
+                    errors={state.errors.fieldErrors.aiMlModelPlan.map((message) => ({
+                      message,
+                    }))}
+                  />
+                ) : (
+                  <FieldDescription>
+                    This helps determine privacy safeguards needed
+                  </FieldDescription>
+                )}
+              </Field>
               <div className="flex gap-4">
                 <Field
                   required


### PR DESCRIPTION
## Summary
- Migrate AI/ML model plans `Select` from MUI to shadcn/base-ui
- Use uncontrolled pattern with `name`/`defaultValue` for native form submission
- Remove `aiMlModelPlan` from action signatures (now part of `formData`)
- Rename MUI `Select` import to `MuiSelect` to avoid collision

Supports #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)