### PR TITLE
[app] Migrate collection period Select to shadcn

### DIFF
--- a/app/src/app/dashboard/NewProjectButton.tsx
+++ b/app/src/app/dashboard/NewProjectButton.tsx
@@ -24,9 +24,7 @@ export function NewProjectButton() {
         New project
       </Button>
       <ProjectDialog
-        action={(collectionPeriod, subreddits, formData) =>
-          createProject(collectionPeriod, subreddits, formData)
-        }
+        action={(subreddits, formData) => createProject(subreddits, formData)}
         infoMessage="This information initialises your DPIA and will flow through all PETLP phases."
         open={open}
         onClose={handleClose}

--- a/app/src/app/dashboard/ProjectCards.tsx
+++ b/app/src/app/dashboard/ProjectCards.tsx
@@ -190,9 +190,7 @@ function ProjectCard({ project }: ProjectCardProps) {
         </DropdownMenuContent>
       </DropdownMenu>
       <ProjectDialog
-        action={(collectionPeriod, subreddits, formData) =>
-          updateProject(project, collectionPeriod, subreddits, formData)
-        }
+        action={(subreddits, formData) => updateProject(project, subreddits, formData)}
         initialProject={project}
         open={editDialogOpen}
         onClose={handleCloseEditDialog}


### PR DESCRIPTION
## Summary
- Migrates the collection period Select from MUI to shadcn/Base UI
- Removes React state for `collectionPeriod` - now uses FormData directly
- Updates Zod schema to parse JSON-stringified values from the form

Supports #177

## Test plan
- [ ] Open project dialog (new project)
- [ ] Verify collection period dropdown renders correctly
- [ ] Select a value and submit form
- [ ] Verify validation error appears when no value is selected
- [ ] Edit existing project and verify value is pre-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)