### PR TITLE
[app] Use Base UI's `Field`

### DIFF
--- a/app/src/app/ApiKeysButton.tsx
+++ b/app/src/app/ApiKeysButton.tsx
@@ -225,7 +225,7 @@ function ApiKeysDialogContent({
                   defaultValue={apiKeys.redditClientSecret}
                 />
               </Field>
-              <Field data-invalid={!!state?.errors.fieldErrors.supabaseProjectUrl?.length}>
+              <Field invalid={!!state?.errors.fieldErrors.supabaseProjectUrl?.length}>
                 <FieldLabel>Supabase project URL</FieldLabel>
                 <Input
                   name={'supabaseProjectUrl' satisfies keyof ApiKeys}

--- a/app/src/app/components/ui/field.tsx
+++ b/app/src/app/components/ui/field.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { createContext, use, useId } from 'react';
+import { createContext, use } from 'react';
+import { Field as FieldPrimitive } from '@base-ui/react/field';
 import { useRender } from '@base-ui/react/use-render';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -9,7 +10,6 @@ import { Label } from '#app/components/ui/label.tsx';
 import { Separator } from '#app/components/ui/separator.tsx';
 
 type FieldContextValue = {
-  id: string;
   required: boolean;
 };
 
@@ -66,7 +66,7 @@ function FieldGroup({ className, ...props }: React.ComponentProps<'div'>) {
 // `Select`'s hidden input uses absolute positioning (set by Base UI),
 // so `Field` needs to be a positioning context when it contains a `Select`.
 const fieldVariants = cva(
-  'data-[invalid=true]:text-destructive group/field flex w-full gap-2 has-[[data-slot=select-trigger]]:relative',
+  'data-invalid:text-destructive group/field flex w-full gap-2 has-[[data-slot=select-trigger]]:relative',
   {
     variants: {
       orientation: {
@@ -88,12 +88,10 @@ function Field({
   orientation = 'vertical',
   required = false,
   ...props
-}: React.ComponentProps<'div'> & VariantProps<typeof fieldVariants> & { required?: boolean }) {
-  const id = useId();
-
+}: FieldPrimitive.Root.Props & VariantProps<typeof fieldVariants> & { required?: boolean }) {
   return (
-    <FieldContext value={{ id, required }}>
-      <div
+    <FieldContext value={{ required }}>
+      <FieldPrimitive.Root
         role="group"
         data-slot="field"
         data-orientation={orientation}
@@ -114,18 +112,12 @@ function FieldContent({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function FieldLabel({
-  children,
-  className,
-  htmlFor,
-  ...props
-}: React.ComponentProps<typeof Label>) {
+function FieldLabel({ children, className, ...props }: React.ComponentProps<typeof Label>) {
   const fieldContext = useFieldContext();
 
   return (
     <Label
       data-slot="field-label"
-      htmlFor={htmlFor ?? fieldContext?.id}
       className={cn(
         'has-data-checked:bg-primary/5 has-data-checked:border-primary dark:has-data-checked:bg-primary/10 group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-2.5',
         'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col',
@@ -160,9 +152,9 @@ function FieldTitle({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function FieldDescription({ className, ...props }: React.ComponentProps<'p'>) {
+function FieldDescription({ className, ...props }: FieldPrimitive.Description.Props) {
   return (
-    <p
+    <FieldPrimitive.Description
       data-slot="field-description"
       className={cn(
         'text-muted-foreground text-left text-sm leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance [[data-variant=legend]+&]:-mt-1.5',

--- a/app/src/app/components/ui/input.tsx
+++ b/app/src/app/components/ui/input.tsx
@@ -6,7 +6,7 @@ import { Input as InputPrimitive } from '@base-ui/react/input';
 import { cn } from '#app/utils/cn.ts';
 import { useFieldContext } from '#app/components/ui/field.tsx';
 
-function Input({ className, defaultValue, id, required, type, ...props }: ComponentProps<'input'>) {
+function Input({ className, defaultValue, required, type, ...props }: ComponentProps<'input'>) {
   const fieldContext = useFieldContext();
 
   let key: Key | undefined;
@@ -20,7 +20,6 @@ function Input({ className, defaultValue, id, required, type, ...props }: Compon
     <InputPrimitive
       key={key}
       type={type}
-      id={id ?? fieldContext?.id}
       required={required ?? fieldContext?.required}
       defaultValue={defaultValue}
       data-slot="input"

--- a/app/src/app/components/ui/label.tsx
+++ b/app/src/app/components/ui/label.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import type * as React from 'react';
+import { Field as FieldPrimitive } from '@base-ui/react/field';
 
 import { cn } from '#app/utils/cn.ts';
 
-function Label({ className, ...props }: React.ComponentProps<'label'>) {
+function Label({ className, ...props }: FieldPrimitive.Label.Props) {
   return (
-    <label
+    <FieldPrimitive.Label
       data-slot="label"
       className={cn(
         'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',

--- a/app/src/app/components/ui/textarea.tsx
+++ b/app/src/app/components/ui/textarea.tsx
@@ -1,23 +1,23 @@
 'use client';
 
 import type * as React from 'react';
+import { Field as FieldPrimitive } from '@base-ui/react/field';
 
 import { cn } from '#app/utils/cn.ts';
 import { useFieldContext } from '#app/components/ui/field.tsx';
 
-function Textarea({ className, id, required, ...props }: React.ComponentProps<'textarea'>) {
+function Textarea({ className, required, ...props }: React.ComponentProps<'textarea'>) {
   const fieldContext = useFieldContext();
 
   return (
-    <textarea
-      id={id ?? fieldContext?.id}
+    <FieldPrimitive.Control
       required={required ?? fieldContext?.required}
       data-slot="textarea"
       className={cn(
         'border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-[3px] md:text-sm',
         className,
       )}
-      {...props}
+      render={<textarea {...props} />}
     />
   );
 }

--- a/app/src/app/dashboard/ProjectDialog.tsx
+++ b/app/src/app/dashboard/ProjectDialog.tsx
@@ -193,7 +193,7 @@ function ProjectDialogContent({
             }}
           >
             <FieldGroup>
-              <Field required data-invalid={!!state?.errors.fieldErrors.title?.length}>
+              <Field required invalid={!!state?.errors.fieldErrors.title?.length}>
                 <FieldLabel>Project title</FieldLabel>
                 <Input
                   name={'title' satisfies keyof ProjectInput}
@@ -213,7 +213,7 @@ function ProjectDialogContent({
                   </FieldDescription>
                 )}
               </Field>
-              <Field required data-invalid={!!state?.errors.fieldErrors.researchObjective?.length}>
+              <Field required invalid={!!state?.errors.fieldErrors.researchObjective?.length}>
                 <FieldLabel>Research objective</FieldLabel>
                 <Textarea
                   name={'researchObjective' satisfies keyof ProjectInput}
@@ -251,10 +251,7 @@ function ProjectDialogContent({
                 )}
               </Field>
               <div className="flex gap-4">
-                <Field
-                  required
-                  data-invalid={!!state?.errors.fieldErrors.estimatedDataVolume?.length}
-                >
+                <Field required invalid={!!state?.errors.fieldErrors.estimatedDataVolume?.length}>
                   <FieldLabel>Estimated data volume</FieldLabel>
                   <Select<EstimatedDataVolume>
                     key={JSON.stringify(initialProject.estimatedDataVolume)}
@@ -287,7 +284,7 @@ function ProjectDialogContent({
                     }))}
                   />
                 </Field>
-                <Field required data-invalid={!!state?.errors.fieldErrors.collectionPeriod?.length}>
+                <Field required invalid={!!state?.errors.fieldErrors.collectionPeriod?.length}>
                   <FieldLabel>Collection period</FieldLabel>
                   <Select
                     key={JSON.stringify(initialProject.collectionPeriod)}
@@ -360,7 +357,7 @@ function ProjectDialogContent({
                   />
                 )}
               />
-              <Field required data-invalid={!!state?.errors.fieldErrors.aiMlModelPlan?.length}>
+              <Field required invalid={!!state?.errors.fieldErrors.aiMlModelPlan?.length}>
                 <FieldLabel>AI/ML model plans</FieldLabel>
                 <Select
                   key={initialProject.aiMlModelPlan}
@@ -395,10 +392,7 @@ function ProjectDialogContent({
                 )}
               </Field>
               <div className="flex gap-4">
-                <Field
-                  required
-                  data-invalid={!!state?.errors.fieldErrors.principalInvestigator?.length}
-                >
+                <Field required invalid={!!state?.errors.fieldErrors.principalInvestigator?.length}>
                   <FieldLabel>Principal investigator</FieldLabel>
                   <Input
                     name={'principalInvestigator' satisfies keyof ProjectInput}
@@ -412,7 +406,7 @@ function ProjectDialogContent({
                     }))}
                   />
                 </Field>
-                <Field required data-invalid={!!state?.errors.fieldErrors.institution?.length}>
+                <Field required invalid={!!state?.errors.fieldErrors.institution?.length}>
                   <FieldLabel>Institution</FieldLabel>
                   <Input
                     name={'institution' satisfies keyof ProjectInput}


### PR DESCRIPTION
## Summary

Migrates custom Field components to use Base UI's Field primitives, which automatically handle the wiring between labels, controls, and descriptions.

### Changes

- `Field` → `FieldPrimitive.Root`
- `FieldLabel` → uses `FieldPrimitive.Label` (via `Label`)
- `FieldDescription` → `FieldPrimitive.Description`
- `Textarea` → `FieldPrimitive.Control`
- Replaces `data-invalid` attribute with Base UI's `invalid` prop

### `data-invalid` attribute behaviour change

Previously we set `data-invalid={boolean}` which renders as `data-invalid="true"` or `data-invalid="false"`, requiring the CSS selector `data-[invalid=true]`.

Base UI's `invalid` prop uses a boolean attribute instead - when true the attribute is present (`data-invalid`), when false it's absent. This allows for the simpler `data-invalid` CSS selector.

### What this removes

- Manual `id` generation with `useId()`
- Manual `htmlFor` wiring between labels and controls
- `id` from `FieldContext` (now only contains `required` for the asterisk indicator)

### Out of scope

Migrating `FieldError` to `Field.Error` is out of scope for this PR.

Closes #271.