### PR TITLE
[app] Migrate MUI `Grid` to Tailwind

### DIFF
--- a/app/src/app/dashboard/GridItem.tsx
+++ b/app/src/app/dashboard/GridItem.tsx
@@ -1,6 +1,0 @@
-import type { ReactNode } from 'react';
-import Grid from '@mui/material/Grid';
-
-export function GridItem({ children }: { children: ReactNode }) {
-  return <Grid size={{ xs: 12, sm: 6, lg: 4 }}>{children}</Grid>;
-}

--- a/app/src/app/dashboard/ProjectCards.tsx
+++ b/app/src/app/dashboard/ProjectCards.tsx
@@ -38,7 +38,6 @@ import {
 } from '#app/components/ui/dropdown-menu.tsx';
 import { updateProject, type Project } from '../actions/project';
 import { db } from '../database';
-import { GridItem } from './GridItem';
 import { ProjectDialog } from './ProjectDialog';
 import { useProjects } from './useProjects';
 
@@ -209,9 +208,5 @@ function ProjectCard({ project }: ProjectCardProps) {
 export function ProjectCards() {
   const projects = useProjects();
 
-  return projects.map((project) => (
-    <GridItem key={project.id}>
-      <ProjectCard project={project} />
-    </GridItem>
-  ));
+  return projects.map((project) => <ProjectCard key={project.id} project={project} />);
 }

--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -1,4 +1,3 @@
-import Grid from '@mui/material/Grid';
 import { AiProviderBanner } from './AiProviderBanner';
 import { NewProjectButton } from './NewProjectButton';
 import { ProjectCards } from './ProjectCards';
@@ -23,9 +22,9 @@ export default function Dashboard() {
           <NewProjectButton />
         </div>
         <ProjectsErrorBoundary>
-          <Grid container spacing={3}>
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
             <ProjectCards />
-          </Grid>
+          </div>
         </ProjectsErrorBoundary>
       </div>
     </div>


### PR DESCRIPTION
Supports #177.

MUI's Grid uses **flexbox** with CSS variables and `calc()` formulas to simulate a grid system. Each item calculates its own width:

```css
/* Container: flex + gap via CSS vars */
.MuiGrid-container {
  display: flex;
  flex-wrap: wrap;
  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing); /* 24px */
}

/* Item: width = calc(100% * columns / total - gap adjustment) */
.MuiGrid-item {
  width: calc(100% * 12/12 - ...);  /* xs: full width */
}
@media (min-width: 600px) {
  width: calc(100% * 6/12 - ...);   /* sm: half */
}
@media (min-width: 1200px) {
  width: calc(100% * 4/12 - ...);   /* lg: third */
}
```

CSS Grid handles this natively — the container defines the layout and items just fill in:

```
<div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
```

| MUI | Tailwind | Effect |
|---|---|---|
| `<Grid container spacing={3}>` | `grid gap-6` | 24px gap between items |
| `size={{ xs: 12 }}` (12/12) | `grid-cols-1` | 1 column on mobile |
| `size={{ sm: 6 }}` (6/12) | `sm:grid-cols-2` | 2 columns at ≥640px |
| `size={{ lg: 4 }}` (4/12) | `lg:grid-cols-3` | 3 columns at ≥1024px |

This removes the need for `GridItem.tsx` entirely — items go directly into the grid container without a wrapper.