### PR TITLE
[app] Fix underline showing under subreddit combobox on focus

### DIFF
--- a/app/src/app/dashboard/ProjectDialog.tsx
+++ b/app/src/app/dashboard/ProjectDialog.tsx
@@ -249,7 +249,8 @@ function SubredditCombobox({ defaultValue }: { defaultValue: string[] }) {
           )}
         </ComboboxValue>
       </ComboboxChips>
-      <ComboboxContent anchor={containerRef}>
+      {/* Hide the popup when empty since we don't render `ComboboxEmpty` */}
+      <ComboboxContent anchor={containerRef} className="data-empty:hidden">
         <ComboboxList>
           {(item: SubredditItem) => (
             <ComboboxItem key={item.value} value={item}>


### PR DESCRIPTION
This is a follow-up to #251.

The subreddit combobox popup opens on focus even when there are no items to display. Since we don't render `ComboboxEmpty`, the popup appears as a thin underline (from its `ring-1` and `shadow-md` styles) below the input.

This adds `data-empty:hidden` to the `ComboboxContent` so the popup is immediately hidden when empty, avoiding any visual flash.